### PR TITLE
fix(ci): add checks:write permission and align Java toolchain to 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
 
     steps:
       - name: Checkout code

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ subprojects {
     plugins.withType<JavaBasePlugin>().configureEach {
         extensions.configure<JavaPluginExtension> {
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(25))
+                languageVersion.set(JavaLanguageVersion.of(21))
                 vendor.set(JvmVendorSpec.ADOPTIUM)
             }
         }


### PR DESCRIPTION
- dorny/test-reporter@v3 requires checks:write to create GitHub Check
  Runs; the workflow-level permissions block only granted contents:read,
  causing the Test Report step to fail with a 403 on every run.
  Add a job-level permissions block to the build job granting both
  contents:read and checks:write, following least-privilege practice.

- Root build.gradle.kts configured subproject Java toolchains to JDK 25
  but .mise.toml only provisions temurin-21. This mismatch caused Gradle
  to attempt toolchain auto-provisioning for the benchmark module during
  configuration. Align the toolchain version to 21 to match mise.

https://claude.ai/code/session_01DJVcU29oyyVBxWUurDUY86